### PR TITLE
fix navigation hierarchy, use top bar and align controls

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -120,6 +120,15 @@ section > header h1 {
 	overflow: auto;
 }
 
+.reload, .all-read, #setstarred, #setunread {
+	float: right;
+	margin-left: 10px;
+}
+
+.settings, .list {
+	float: left;
+}
+
 section > footer {
 	padding: 10px;
 	position: fixed;

--- a/index.html
+++ b/index.html
@@ -18,15 +18,15 @@
 <body>
 
 <section id="list" class="active">
+  <header class="bar">
+    <a class="button icon settings" href="#settings">&#9881;</a>
+    <a class="button icon reload" href="#reload">&#128260;</a>
+    <a class="button icon all-read" href="#all-read" id="all-read">❌</a>
+    <canvas width="40" height="40"></canvas>
+  </header>
   <article>
     <ul></ul>
   </article>
-  <footer class="bar">
-    <a class="button icon" href="#reload">&#128260;</a>
-    <a class="button icon" href="#all-read" id="all-read">❌</a>
-    <a class="button icon" href="#settings">&#9881;</a>
-    <canvas width="40" height="40"></canvas>
-  </footer>
 </section>
 
 <section id="settings">
@@ -83,9 +83,9 @@
 
 <section id="full">
   <header class="bar">
-    <a class="button icon" href="#list">&#57349;</a>
-    <a id="setunread" class="button icon" href="#unread">✓</a>
+    <a class="button icon list" href="#list">&#57349;</a>
     <a id="setstarred" class="button icon" href="#starred">&#9734;</a>
+    <a id="setunread" class="button icon" href="#unread">✓</a>
     <canvas width="40" height="40"></canvas>
   </header>
   <article>


### PR DESCRIPTION
Currently there are 3 views:
- Settings
- Article list
- Article detail

In the article list, the navigation is on the bottom, and in the article detail, the main navigation (except the article switcher arrows) is on the top.

I’d recommend to put the navigation on top in both views to keep it consistent. It’s also kind of a hierarchy, drilling down more to the right into the detail view, and to the left into the list. And settings are leftmost.
